### PR TITLE
only same lessons can be merged

### DIFF
--- a/apps/iris/src/components/admin/substitution-dialog.tsx
+++ b/apps/iris/src/components/admin/substitution-dialog.tsx
@@ -183,7 +183,7 @@ export function SubstitutionDialog({
       if (!(lesson.subject && selectedSubjectIds.has(lesson.subject.id))) {
         continue;
       }
-      for (const teacher of lesson.teachers) {
+      for (const teacher of lesson.teachers ?? []) {
         if (!seen.has(teacher.id)) {
           seen.set(teacher.id, { id: teacher.id, name: teacher.name });
         }

--- a/apps/iris/src/components/admin/substitution-dialog.tsx
+++ b/apps/iris/src/components/admin/substitution-dialog.tsx
@@ -98,15 +98,14 @@ export function SubstitutionDialog({
   const [selectedMissingTeacher, setSelectedMissingTeacher] =
     useState<string>('');
   const defaultValues = useMemo(() => initialState(item), [item]);
-  const parallelTeacherRef = useRef<{ id: string; name: string } | null>(null);
+  const parallelTeachersRef = useRef<Map<string, string>>(new Map());
 
   const form = useForm({
     defaultValues,
     onSubmit: async ({ value }) => {
-      const resolvedSubstituter =
-        value.substituter === '__merged__'
-          ? (parallelTeacherRef.current?.id ?? null)
-          : value.substituter;
+      const resolvedSubstituter = value.substituter?.startsWith('__merged__:')
+        ? (parallelTeachersRef.current.get(value.substituter) ?? null)
+        : value.substituter;
       await onSubmit({ ...value, substituter: resolvedSubstituter });
     },
   });
@@ -173,17 +172,33 @@ export function SubstitutionDialog({
       []) as TeacherLesson[];
   }, [selectedMissingTeacher, substituteCandidatesQuery.data]);
 
-  const parallelTeacher = useMemo(() => {
-    const lessons = substituteCandidatesQuery.data?.parallelLessons ?? [];
-    const firstTeacher = lessons[0]?.teachers[0];
-    return firstTeacher ?? null;
-  }, [substituteCandidatesQuery.data]);
+  const parallelTeachers = useMemo(() => {
+    const parallelLessons =
+      substituteCandidatesQuery.data?.parallelLessons ?? [];
+    const selectedSubjectIds = new Set(
+      availableLessons
+        .filter((l) => formLessonIds.includes(l.id) && l.subject)
+        .map((l) => l.subject?.id)
+    );
+    const seen = new Map<string, { id: string; name: string }>();
+    for (const lesson of parallelLessons) {
+      if (!(lesson.subject && selectedSubjectIds.has(lesson.subject.id))) {
+        continue;
+      }
+      for (const teacher of lesson.teachers) {
+        if (!seen.has(teacher.id)) {
+          seen.set(teacher.id, { id: teacher.id, name: teacher.name });
+        }
+      }
+    }
+    return [...seen.values()];
+  }, [substituteCandidatesQuery.data, availableLessons, formLessonIds]);
 
   useEffect(() => {
-    parallelTeacherRef.current = parallelTeacher
-      ? { id: parallelTeacher.id, name: parallelTeacher.name }
-      : null;
-  }, [parallelTeacher]);
+    parallelTeachersRef.current = new Map(
+      parallelTeachers.map((pt) => [`__merged__:${pt.id}`, pt.id])
+    );
+  }, [parallelTeachers]);
 
   const substituteOptions = useMemo(() => {
     const candidates =
@@ -333,14 +348,10 @@ export function SubstitutionDialog({
                     label: t('substitution.cancelled'),
                     value: '__none__',
                   },
-                  ...(parallelTeacher
-                    ? [
-                        {
-                          label: t('substitution.merged'),
-                          value: '__merged__',
-                        },
-                      ]
-                    : []),
+                  ...parallelTeachers.map((teacher) => ({
+                    label: `${t('substitution.merged')} - ${teacher.name}`,
+                    value: `__merged__:${teacher.id}`,
+                  })),
                   ...substituteOptions,
                 ]}
                 placeholder={t('substitution.substituteTeacher')}

--- a/apps/iris/src/components/admin/substitution-dialog.tsx
+++ b/apps/iris/src/components/admin/substitution-dialog.tsx
@@ -6,7 +6,7 @@ import {
   parseResponse,
 } from 'hono/client';
 import { Save } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -98,13 +98,11 @@ export function SubstitutionDialog({
   const [selectedMissingTeacher, setSelectedMissingTeacher] =
     useState<string>('');
   const defaultValues = useMemo(() => initialState(item), [item]);
-  const parallelTeachersRef = useRef<Map<string, string>>(new Map());
-
   const form = useForm({
     defaultValues,
     onSubmit: async ({ value }) => {
       const resolvedSubstituter = value.substituter?.startsWith('__merged__:')
-        ? (parallelTeachersRef.current.get(value.substituter) ?? null)
+        ? value.substituter.slice('__merged__:'.length)
         : value.substituter;
       await onSubmit({ ...value, substituter: resolvedSubstituter });
     },
@@ -193,12 +191,6 @@ export function SubstitutionDialog({
     }
     return [...seen.values()];
   }, [substituteCandidatesQuery.data, availableLessons, formLessonIds]);
-
-  useEffect(() => {
-    parallelTeachersRef.current = new Map(
-      parallelTeachers.map((pt) => [`__merged__:${pt.id}`, pt.id])
-    );
-  }, [parallelTeachers]);
 
   const substituteOptions = useMemo(() => {
     const candidates =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Substitution dialog now supports selecting multiple merged/parallel teachers instead of a single inferred teacher.
  * Selection list shows a separate merged option for each available parallel teacher with clear merged labels.
  * Form submission correctly resolves merged selections so the chosen underlying teacher is applied.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/filcdev/filc/pull/196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->