### PR TITLE
fix(iris): read dashboard stats from nested data.stats envelope

### DIFF
--- a/apps/iris/src/components/admin/dashboard.tsx
+++ b/apps/iris/src/components/admin/dashboard.tsx
@@ -39,14 +39,14 @@ export function AdminDashboard() {
     { label: t('dashboard.lastYear'), value: '365' },
   ];
 
-  const statsQuery = useApiQuery<DashboardStats>(
+  const statsQuery = useApiQuery<NonNullable<StatsResponse['data']>>(
     () => api.dashboard.stats.$get({ query: { days: String(days) } }),
     {
       queryKey: ['dashboard', 'stats', days] as const,
     }
   );
 
-  const stats = statsQuery.data;
+  const stats: DashboardStats | undefined = statsQuery.data?.stats;
   const isLoading = statsQuery.isLoading;
 
   const filteredChartData = useMemo(() => {


### PR DESCRIPTION
closes #268 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard statistics handling to ensure displayed metrics are correctly extracted from the API response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->