### PR TITLE
fix(iris): keep substitutions and moved-lessons toolbars responsive o…

### DIFF
--- a/apps/iris/src/components/admin/moved-lesson-export.tsx
+++ b/apps/iris/src/components/admin/moved-lesson-export.tsx
@@ -41,6 +41,7 @@ export function MovedLessonExportButton({
       errorKey="movedLesson.exportError"
       fetchCsv={fetchCsv}
       filenamePrefix="moved-lessons"
+      hideLabelOnMobile
       labelKey="movedLesson.export"
       pdfTitle={t('movedLesson.exportTitle')}
       successKey="movedLesson.exportSuccess"

--- a/apps/iris/src/components/admin/substitution-export.tsx
+++ b/apps/iris/src/components/admin/substitution-export.tsx
@@ -40,6 +40,7 @@ export function SubstitutionExportButton({
       errorKey="substitution.exportError"
       fetchCsv={fetchCsv}
       filenamePrefix="substitutions"
+      hideLabelOnMobile
       labelKey="substitution.export"
       pdfTitle={t('substitution.exportTitle')}
       successKey="substitution.exportSuccess"

--- a/apps/iris/src/components/export-button.tsx
+++ b/apps/iris/src/components/export-button.tsx
@@ -19,6 +19,8 @@ export type ExportColumn = {
 type ExportButtonProps = {
   /** i18n key for the button label (defaults to `export`). */
   labelKey?: string;
+  /** Hide the label below the `sm` breakpoint (icon-only on mobile). */
+  hideLabelOnMobile?: boolean;
   /** i18n key for the success toast. */
   successKey: string;
   /** i18n key for the error toast. */
@@ -139,6 +141,7 @@ export function ExportButton({
   errorKey,
   fetchCsv,
   filenamePrefix,
+  hideLabelOnMobile = false,
   labelKey = 'export',
   pdfTitle,
   successKey,
@@ -192,9 +195,18 @@ export function ExportButton({
     <DropdownMenu>
       <DropdownMenuTrigger
         render={
-          <Button disabled={exporting} size="sm" variant="outline">
+          <Button
+            aria-label={hideLabelOnMobile ? t(labelKey) : undefined}
+            disabled={exporting}
+            size="sm"
+            variant="outline"
+          >
             <Download className="h-4 w-4" />
-            {t(labelKey)}
+            {hideLabelOnMobile ? (
+              <span className="hidden sm:inline">{t(labelKey)}</span>
+            ) : (
+              t(labelKey)
+            )}
           </Button>
         }
       />

--- a/apps/iris/src/routes/_private/admin/timetable/moved-lessons.tsx
+++ b/apps/iris/src/routes/_private/admin/timetable/moved-lessons.tsx
@@ -344,22 +344,31 @@ function MovedLessonsPage() {
             {t('movedLesson.showPast')}
           </label>
         </div>
-        <div className="flex items-center gap-2 sm:ml-auto">
-          <DateRangePicker onChange={setDateRange} value={dateRange} />
+        <div className="flex w-full flex-wrap items-center gap-2 sm:ml-auto sm:w-auto">
+          <div className="w-fit">
+            <DateRangePicker onChange={setDateRange} value={dateRange} />
+          </div>
           <MovedLessonExportButton dateRange={dateRange} />
-          <Button onClick={() => movedLessonsQuery.refetch()} variant="outline">
+          <Button
+            aria-label={t('movedLesson.refresh')}
+            onClick={() => movedLessonsQuery.refetch()}
+            variant="outline"
+          >
             <RefreshCw className="h-4 w-4" />
-            {t('movedLesson.refresh')}
+            <span className="hidden sm:inline">{t('movedLesson.refresh')}</span>
           </Button>
           {hasWritePermission && (
             <Button
+              aria-label={t('movedLesson.create')}
               onClick={() => {
                 setSelectedItem(null);
                 setDialogOpen(true);
               }}
             >
               <Plus className="h-4 w-4" />
-              {t('movedLesson.create')}
+              <span className="hidden sm:inline">
+                {t('movedLesson.create')}
+              </span>
             </Button>
           )}
         </div>

--- a/apps/iris/src/routes/_private/admin/timetable/substitutions.tsx
+++ b/apps/iris/src/routes/_private/admin/timetable/substitutions.tsx
@@ -208,25 +208,33 @@ function SubstitutionsPage() {
             {t('substitution.showPast')}
           </label>
         </div>
-        <div className="flex items-center gap-2 sm:ml-auto">
-          <DateRangePicker onChange={setDateRange} value={dateRange} />
+        <div className="flex w-full flex-wrap items-center gap-2 sm:ml-auto sm:w-auto">
+          <div className="w-fit">
+            <DateRangePicker onChange={setDateRange} value={dateRange} />
+          </div>
           <SubstitutionExportButton dateRange={dateRange} />
           <Button
+            aria-label={t('substitution.refresh')}
             onClick={() => substitutionsQuery.refetch()}
             variant="outline"
           >
             <RefreshCw className="h-4 w-4" />
-            {t('substitution.refresh')}
+            <span className="hidden sm:inline">
+              {t('substitution.refresh')}
+            </span>
           </Button>
           {hasWritePermission && (
             <Button
+              aria-label={t('substitution.create')}
               onClick={() => {
                 setSelectedItem(null);
                 setDialogOpen(true);
               }}
             >
               <Plus className="h-4 w-4" />
-              {t('substitution.create')}
+              <span className="hidden sm:inline">
+                {t('substitution.create')}
+              </span>
             </Button>
           )}
         </div>


### PR DESCRIPTION
…n mobile

Wrap the inner action row and constrain the DateRangePicker width so all toolbar controls stay inside the viewport on mobile, and collapse the Refresh/Create/Export button labels to icons below the sm breakpoint.

- substitutions.tsx / moved-lessons.tsx: action row now uses `flex w-full flex-wrap items-center gap-2 sm:ml-auto sm:w-auto`; DateRangePicker wrapped in `w-fit`; buttons use `hidden sm:inline` labels plus `aria-label` from the existing i18n keys.
- export-button.tsx: add optional `hideLabelOnMobile` prop (default false) for icon-only rendering on mobile; default unchanged for other callers.
- substitution-export.tsx / moved-lesson-export.tsx: pass `hideLabelOnMobile` to ExportButton.

closes #269 