### PR TITLE
fix(iris): allow horizontal scroll for doorlock device stats table

### DIFF
--- a/apps/iris/src/components/doorlock/device-stats-dialog.tsx
+++ b/apps/iris/src/components/doorlock/device-stats-dialog.tsx
@@ -193,7 +193,7 @@ export function DeviceStatsDialog({
               <div className="space-y-2">
                 <h3 className="font-semibold text-sm">Recent History</h3>
                 <div className="rounded-md border">
-                  <Table className="w-full table-fixed">
+                  <Table className="w-full min-w-3xl table-fixed">
                     <TableHeader>
                       <TableRow>
                         <TableHead>Time</TableHead>


### PR DESCRIPTION
## Summary

Fixes the "Recent History" table in the doorlock **Device Statistics** dialog, where the mono timestamp (`YYYY-MM-DD HH:mm:ss`) bled into the State column on small screens, making both columns unreadable.

## Change

Added `min-w-3xl` to the `<Table>` so it holds a 768px minimum width and horizontally scrolls on narrow screens via the shared `Table` component's built-in `overflow-x-auto` wrapper — the same pattern used by every other admin table in Iris.

```diff
-<Table className="w-full table-fixed">
+<Table className="w-full min-w-3xl table-fixed">
```

No other files touched. `biome check` and `typecheck` pass.

Closes #270


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the recent history table layout by enforcing a minimum width, helping maintain consistent alignment and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->