### PR TITLE
feat: searchable owner picker in doorlock card dialog

### DIFF
--- a/apps/iris/public/locales/en/translation.json
+++ b/apps/iris/public/locales/en/translation.json
@@ -580,6 +580,8 @@
     "disabledCards": "Disabled Cards",
     "name": "Name",
     "owner": "Owner",
+    "selectOwnerPlaceholder": "Select owner",
+    "noUsersFound": "No users found.",
     "status": "Status",
     "authorizedDevices": "Authorized Devices",
     "updatedAt": "Updated",

--- a/apps/iris/public/locales/hu/translation.json
+++ b/apps/iris/public/locales/hu/translation.json
@@ -580,6 +580,8 @@
     "disabledCards": "Letiltott kártyák",
     "name": "Név",
     "owner": "Tulajdonos",
+    "selectOwnerPlaceholder": "Tulajdonos kiválasztása",
+    "noUsersFound": "Nem található felhasználó.",
     "status": "Állapot",
     "authorizedDevices": "Engedélyezett eszközök",
     "updatedAt": "Frissítve",

--- a/apps/iris/src/components/doorlock/card-dialog.tsx
+++ b/apps/iris/src/components/doorlock/card-dialog.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { getOwnerLabel } from '@/components/doorlock/doorlock.utils';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
+import { Combobox } from '@/components/ui/combobox';
 import {
   Dialog,
   DialogContent,
@@ -14,7 +15,6 @@ import {
 } from '@/components/ui/dialog';
 import { Field, FieldError, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
-import { Select, SelectTrigger, SelectValue } from '@/components/ui/select';
 import {
   useUpsertCardFromLog,
   useUpsertDoorlockCard,
@@ -150,19 +150,18 @@ export function CardDialog<
           <form.Field name="userId">
             {(field) => (
               <Field>
-                <FieldLabel>Owner</FieldLabel>
-                <Select
-                  items={users.map((user) => ({
+                <FieldLabel>{t('doorlockCards.owner')}</FieldLabel>
+                <Combobox
+                  emptyMessage={t('doorlockCards.noUsersFound')}
+                  onValueChange={(value) => field.handleChange(value || null)}
+                  options={users.map((user) => ({
                     label: getOwnerLabel(user) || t('doorlock.unknownUser'),
                     value: user.id,
                   }))}
-                  onValueChange={(value) => field.handleChange(value ?? null)}
-                  value={field.state.value}
-                >
-                  <SelectTrigger className="w-full">
-                    <SelectValue />
-                  </SelectTrigger>
-                </Select>
+                  placeholder={t('doorlockCards.selectOwnerPlaceholder')}
+                  searchPlaceholder={t('search')}
+                  value={field.state.value ?? ''}
+                />
               </Field>
             )}
           </form.Field>


### PR DESCRIPTION
## Summary

Replaces the plain owner dropdown in the doorlock card dialog with the reusable searchable `Combobox`, and completes the owner control's i18n.

## Changes

- `card-dialog.tsx`: the `userId` field now uses `Combobox` (searchable) with `getOwnerLabel` fallback to `doorlock.unknownUser`; null-owner selection round-trips in both create and edit.
- Added `doorlockCards.selectOwnerPlaceholder` and `doorlockCards.noUsersFound` to `en` and `hu`.
