### PR TITLE
Allow selecting no class

### DIFF
--- a/apps/iris/public/locales/en/translation.json
+++ b/apps/iris/public/locales/en/translation.json
@@ -92,6 +92,7 @@
     "errorLoading": "Error loading cohorts: {{message}}",
     "selectPlaceholder": "Select cohort",
     "noneFound": "No cohorts found",
+    "noClass": "No class",
     "select": "Select your cohort"
   },
   "search": "Search",

--- a/apps/iris/public/locales/hu/translation.json
+++ b/apps/iris/public/locales/hu/translation.json
@@ -59,6 +59,7 @@
     "errorLoading": "Hiba a csoportok betöltése közben: {{message}}",
     "fetchFailed": "A csoportok lekérése nem sikerült",
     "noneFound": "Nem található csoport",
+    "noClass": "Nincs osztály",
     "selectPlaceholder": "Csoport kiválasztása",
     "select": "Válaszd ki a csoportodat"
   },

--- a/apps/iris/src/components/settings-dialog.tsx
+++ b/apps/iris/src/components/settings-dialog.tsx
@@ -53,6 +53,10 @@ const NOTIFICATION_TYPES = [
   },
 ];
 
+// Sentinel value for the "no class" choice in the cohort <Select>.
+// Cohort ids are UUIDs, so this cannot collide with a real id.
+const NO_CLASS_VALUE = 'no-class';
+
 type SettingsDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -115,9 +119,11 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
     },
     updateCohort: async () => {
       const currentCohortId = session?.user?.cohortId ?? null;
-      if (cohortQuery.isSuccess && selectedCohortId !== currentCohortId) {
+      const newCohortId =
+        selectedCohortId === NO_CLASS_VALUE ? null : selectedCohortId;
+      if (cohortQuery.isSuccess && newCohortId !== currentCohortId) {
         try {
-          await authClient.updateUser({ cohortId: selectedCohortId });
+          await authClient.updateUser({ cohortId: newCohortId });
         } catch {
           throw new Error('Failed to update cohort');
         }
@@ -173,10 +179,13 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
     { label: t('preferences.themeSystem'), value: 'system' },
   ];
 
-  const cohortItems = (cohortQuery.data ?? []).map((cohort) => ({
-    label: cohort.name,
-    value: cohort.id,
-  }));
+  const cohortItems = [
+    { label: t('cohort.noClass'), value: NO_CLASS_VALUE },
+    ...(cohortQuery.data ?? []).map((cohort) => ({
+      label: cohort.name,
+      value: cohort.id,
+    })),
+  ];
 
   const ready = !(isLoading || isError);
 

--- a/apps/iris/src/routes/auth/welcome.tsx
+++ b/apps/iris/src/routes/auth/welcome.tsx
@@ -341,6 +341,14 @@ const CohortSelectorStep = (props: {
     return success;
   };
 
+  const clearCohort = async () => {
+    setIsUpdating(true);
+    setOpen(false);
+    const success = await props.onSkip();
+    setIsUpdating(false);
+    return success;
+  };
+
   if (
     cohortQuery.isLoading ||
     (!props.userCohortId && activeTimetableQuery.isLoading)
@@ -387,6 +395,20 @@ const CohortSelectorStep = (props: {
             <CommandList>
               <CommandEmpty>{t('cohort.noneFound')}</CommandEmpty>
               <CommandGroup>
+                <CommandItem
+                  onSelect={() => clearCohort()}
+                  value={t('cohort.noClass')}
+                >
+                  {t('cohort.noClass')}
+                  <Check
+                    className={cn(
+                      'ml-auto',
+                      props.selectedCohortId === null
+                        ? 'opacity-100'
+                        : 'opacity-0'
+                    )}
+                  />
+                </CommandItem>
                 {cohortQuery.data.map((cohort) => (
                   <CommandItem
                     key={cohort.id}


### PR DESCRIPTION
## Summary

Lets users opt out of selecting a class ("No class") in both cohort pickers. Closes #292

## Changes

- Add a "No class" entry at the top of the onboarding cohort dropdown; selecting it persists `cohortId: null` for everyone (previously only staff could skip)
- Add a "No class" option to the preferences cohort `<Select>`, backed by a `'no-class'` sentinel that maps to `null` on save
- Add `cohort.noClass` strings to both `en` and `hu` locale trees

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run build` — if bundler config, routers, or server entrypoints changed
- [x] Translations added to both `apps/iris/public/locales/en/translation.json` and `apps/iris/public/locales/hu/translation.json` — if user-facing text changed
- [ ] Migration generated with `bun run db:generate` and committed — if the schema changed
